### PR TITLE
onChange event not always created

### DIFF
--- a/src/SegmentedControl.js
+++ b/src/SegmentedControl.js
@@ -40,7 +40,7 @@ const SegmentedControl = React.createClass({
             type="radio"
             name={this.props.name}
             id={getId(option)}
-            onChange={() => this.setValue(option.value)}
+            onClick={() => this.setValue(option.value)}
             defaultChecked={option.default}
             disabled={option.disabled}
             />

--- a/src/SegmentedControl.js
+++ b/src/SegmentedControl.js
@@ -36,11 +36,11 @@ const SegmentedControl = React.createClass({
         >
         {this.props.options.map(option => (
           <input
-            key={option.value}
+            key={getId(option)}
             type="radio"
             name={this.props.name}
             id={getId(option)}
-            onClick={() => this.setValue(option.value)}
+            onChange={() => this.setValue(option.value)}
             defaultChecked={option.default}
             disabled={option.disabled}
             />
@@ -48,7 +48,7 @@ const SegmentedControl = React.createClass({
         }
         {this.props.options.map(option => (
           <label
-            key={option.value}
+            key={getId(option)}
             htmlFor={getId(option)}
             data-value={option.label}
             >


### PR DESCRIPTION
Apologize for not having the full detail, but I recently updated all my npm modules and this stopped working properly. I have no idea which module caused it to break. Specifically, you could click a segment and onChange would be called. Click back to the first segment and onChange would not be called—in fact, it wouldn't ever be called again.

I switched the key to use the id that's generated internally and that solved my issue.

OF NOTE: changing from onChange to onClick did NOT solve the problem, hence the further change to the key.