### PR TITLE
Add SegmentedControlWithoutStyles for usage with Next.js

### DIFF
--- a/src/SegmentedControl.js
+++ b/src/SegmentedControl.js
@@ -1,68 +1,13 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import find from 'lodash/find'
-import extend from 'lodash/extend'
+import React from 'react'
+import SegmentedControlWithoutStyles from './SegmentedControlWithoutStyles'
 
 import './SegmentedControl.css'
 
-class SegmentedControl extends Component {
-  static propTypes = {
-    className: PropTypes.string,
-    name: PropTypes.string.isRequired,
-    options: PropTypes.array.isRequired,
-    style: PropTypes.object,
-    setValue: PropTypes.func
-  }
-
-  componentWillMount() {
-    const defaultOption = find(this.props.options, { default: true })
-    this.setValue(defaultOption.value)
-  }
-
-  setValue(val) {
-    this.props.setValue && this.props.setValue(val)
-  }
-
-  render() {
-    const getId = option => this.props.name + option.value
-
-    const defaultStyle = {
-      width: '100%'
-    }
-
-    const style = extend(defaultStyle, this.props.style)
-
-    let containerClassName = 'segmented-control'
-    
-    if (typeof this.props.className !== 'undefined') {
-      containerClassName = `${containerClassName} ${this.props.className}`
-    }
-
-    return (
-      <div className={containerClassName} style={style}>
-        {this.props.options.map(option => (
-          <input
-            key={option.value}
-            type="radio"
-            name={this.props.name}
-            id={getId(option)}
-            defaultChecked={option.default}
-            disabled={option.disabled}
-          />
-        ))}
-        {this.props.options.map(option => (
-          <label
-            key={option.value}
-            onClick={() => this.setValue(option.value)}
-            htmlFor={getId(option)}
-            data-value={option.label}
-          >
-            {option.label}
-          </label>
-        ))}
-      </div>
-    )
-  }
-}
-
+const SegmentedControl = (props) => (
+  <SegmentedControlWithoutStyles
+    {...props}
+  />
+)
+  
 export default SegmentedControl
+

--- a/src/SegmentedControlWithoutStyles.js
+++ b/src/SegmentedControlWithoutStyles.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import find from 'lodash/find'
+import extend from 'lodash/extend'
+
+class SegmentedControlWithoutStyles extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    name: PropTypes.string.isRequired,
+    options: PropTypes.array.isRequired,
+    style: PropTypes.object,
+    setValue: PropTypes.func
+  }
+
+  componentWillMount() {
+    const defaultOption = find(this.props.options, { default: true })
+    this.setValue(defaultOption.value)
+  }
+
+  setValue(val) {
+    this.props.setValue && this.props.setValue(val)
+  }
+
+  render() {
+    const getId = option => this.props.name + option.value
+
+    const defaultStyle = {
+      width: '100%'
+    }
+
+    const style = extend(defaultStyle, this.props.style)
+
+    let containerClassName = 'segmented-control'
+    
+    if (typeof this.props.className !== 'undefined') {
+      containerClassName = `${containerClassName} ${this.props.className}`
+    }
+
+    return (
+      <div className={containerClassName} style={style}>
+        {this.props.options.map(option => (
+          <input
+            key={option.value}
+            type="radio"
+            name={this.props.name}
+            id={getId(option)}
+            defaultChecked={option.default}
+            disabled={option.disabled}
+          />
+        ))}
+        {this.props.options.map(option => (
+          <label
+            key={option.value}
+            onClick={() => this.setValue(option.value)}
+            htmlFor={getId(option)}
+            data-value={option.label}
+          >
+            {option.label}
+          </label>
+        ))}
+      </div>
+    )
+  }
+}
+
+export default SegmentedControlWithoutStyles

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export SegmentedControl from './SegmentedControl'
+export SegmentedControlWithoutStyles from './SegmentedControlWithoutStyles'
 export FormsySegmentedControl from './FormsySegmentedControl'

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -7,6 +7,7 @@ import RaisedButton from 'material-ui/RaisedButton'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 
 import SegmentedControl from '../SegmentedControl'
+import SegmentedControlWithoutStyles from '../SegmentedControlWithoutStyles'
 import FormsySegmentedControl from '../FormsySegmentedControl'
 
 storiesOf('SegmentedControl', module)
@@ -95,4 +96,18 @@ storiesOf('FormsySegmentedControl', module)
         />
       </Formsy>
     </MuiThemeProvider>
+  ))
+
+storiesOf('SegmentedControlWithoutStyles', module)
+  .addDecorator(centered)
+  .add('Two options without styles', () => (
+    <SegmentedControlWithoutStyles
+      className="custom-class"
+      name="twoOptions"
+      options={[
+        { label: 'One', value: 'one', default: true },
+        { label: 'Two', value: 'two' }
+      ]}
+      setValue={action('setValue')}
+    />
   ))


### PR DESCRIPTION
In Next.js, and in other environments that don't support style imports from `node_modules`, Segmented Control is a pain to use.

To solve this, I isolated the core React code in one file (`SegmentedControlWithoutStyles.js`), and turned `SegmentedControl.js` into a simple wrapper which also imports `SegmentedControl.css`.

For existing users, nothing changes. The `SegmentedControl` import stays the same and works the same way as before.

However, developers using Next.js can now `import { SegmentedControlWithoutStyles } from "segmented-control"`, and import `SegmentedControl.css` using their own preferred ways.