### PR TITLE
Fix invalid exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "license": "MIT",
   "main": "dist/index.js",
   "exports": {
-    ".": "dist/index.js",
-    "./SegmentedControlWithoutStyles": "dist/SegmentedControlWithoutStyles.js",
-    "./SegmentedControl": "dist/SegmentedControl.js",
-    "./FormsySegmentedControl": "dist/FormsySegmentedControl.js"
+    ".": "./dist/index.js",
+    "./SegmentedControlWithoutStyles": "./dist/SegmentedControlWithoutStyles.js",
+    "./SegmentedControl": "./dist/SegmentedControl.js",
+    "./FormsySegmentedControl": "./dist/FormsySegmentedControl.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## What was changed

The `exports` in `package.json` has been updated to a valid format. They just needed to start with `./`

## Why?
<!-- Tell your future self why have you made these changes -->

Using Next.js + TypeScript + Node.js 16, could not build because the exports in `package.json` were invalid. 

```
> Build error occurred
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" target "dist/SegmentedControlWithoutStyles.js" defined for './SegmentedControlWithoutStyles' in the package config node_modules/segmented-control/package.json; targets must start with "./"
    at new NodeError (node:internal/errors:363:5)
    at throwInvalidPackageTarget (node:internal/modules/esm/resolve:340:9)
    at resolvePackageTargetString (node:internal/modules/esm/resolve:368:5)
    at resolvePackageTarget (node:internal/modules/esm/resolve:405:12)
    at packageExportsResolve (node:internal/modules/esm/resolve:506:22)
    at resolveExports (node:internal/modules/cjs/loader:478:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:518:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:927:27)
    at Function.Module._load (node:internal/modules/cjs/loader:774:27)
    at Module.require (node:internal/modules/cjs/loader:1013:19) {
  type: 'Error',
  code: 'ERR_INVALID_PACKAGE_TARGET'

```

## Checklist

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Against a private Next.js + TypeScript + Node.js 16 project.

3. Any docs updates needed?

No
